### PR TITLE
add gasLimit to usePrepareContractWrite

### DIFF
--- a/src/components/Modals/VerifyModal.tsx
+++ b/src/components/Modals/VerifyModal.tsx
@@ -34,7 +34,16 @@ const VerifyModal: FC<Props> = ({ profile, onVerify, onReturn, modalState }) => 
 		enabled: !!profile && !!proof,
 		contractInterface: HumanCheck,
 		addressOrName: process.env.NEXT_PUBLIC_CONTRACT_ADDRESS,
-		args: [profile?.id, proof?.merkle_root, proof?.nullifier_hash, decodeProof(proof?.proof)],
+		args: [
+			profile?.id,
+			proof?.merkle_root,
+			proof?.nullifier_hash,
+			decodeProof(proof?.proof),
+			{
+				gasLimit: 1300000,
+				value: 2,
+			},
+		],
 	})
 
 	const { write } = useContractWrite({ ...config, onSuccess: onVerify })


### PR DESCRIPTION
[WID-167](https://linear.app/worldcoin/issue/WID-167/edge-case-verifying-humans-on-lens)

The problem is in [this](https://github.com/worldcoin/world-id-lens-dapp/blob/main/src/components/Modals/VerifyModal.tsx#L105) "disable" condition for the Button. Seems like the [useContractWrite](https://github.com/worldcoin/world-id-lens-dapp/blob/main/src/components/Modals/VerifyModal.tsx#L40) hook always returns `undefined` for the `write` function. That's why the button is disabled.

Added `{ gasLimit: 1300000, value: 2}` object as the last element of the [args](https://github.com/worldcoin/world-id-lens-dapp/blob/main/src/components/Modals/VerifyModal.tsx#L37) array in the usePrepareContractWrite props object as suggested in `wagmi` GitHub [issue](https://github.com/wagmi-dev/wagmi/issues/794). It's working for me.